### PR TITLE
DO NOT MERGE:  Adds an IsDebug flat to InitOptions

### DIFF
--- a/examples/HelloWorld/MauiProgram.cs
+++ b/examples/HelloWorld/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Aptabase.Maui;
+using Microsoft.Extensions.Logging;
 
 namespace HelloWorld;
 
@@ -9,7 +10,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
-            .UseAptabase("A-DEV-0000000000")
+            .UseAptabase("A-DEV-0000000000", new InitOptions(){IsDebug = true})
             .ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -25,4 +26,3 @@ public static class MauiProgram
 		return builder.Build();
 	}
 }
-

--- a/package/AptabaseClient.cs
+++ b/package/AptabaseClient.cs
@@ -26,6 +26,7 @@ public class AptabaseClient : IAptabaseClient
     private readonly HttpClient? _http;
     private DateTime _lastTouched = DateTime.UtcNow;
     private string _sessionId = NewSessionId();
+    private bool IsDebug = false;
 
     private static readonly Dictionary<string, string> _hosts = new()
     {
@@ -44,7 +45,7 @@ public class AptabaseClient : IAptabaseClient
     public AptabaseClient(string appKey, InitOptions? options, ILogger<AptabaseClient>? logger)
     {
         _logger = logger;
-
+        IsDebug = options?.IsDebug == true;
         var parts = appKey.Split("-");
         if (parts.Length != 3 || !_hosts.ContainsKey(parts[1]))
         {
@@ -117,7 +118,7 @@ public class AptabaseClient : IAptabaseClient
                 eventName,
                 systemProps = new
                 {
-                    isDebug = _sysInfo.IsDebug,
+                    isDebug = _sysInfo.IsDebug || IsDebug,
                     osName = _sysInfo.OsName,
                     osVersion = _sysInfo.OsVersion,
                     locale = _sysInfo.Locale,
@@ -148,4 +149,3 @@ public class AptabaseClient : IAptabaseClient
         return (epochInSeconds * 100000000 + random).ToString();
     }
 }
-

--- a/package/InitOptions.cs
+++ b/package/InitOptions.cs
@@ -10,4 +10,10 @@ public class InitOptions
 	/// Custom host for Self-Hosted instances
 	/// </summary>
 	public string? Host { get; set; }
+
+	/// <summary>
+	/// Manual overide to make the client run in debug mode
+	/// </summary>
+	public bool IsDebug { get; set; }
+
 }


### PR DESCRIPTION
Note: MAUI and VS just had an update, and as usual, this breaks all my projects builds. So, I cannot build this project presently (`ResolveTargetingPackAssets` tasks failed). Things will likely fix magically as reboots happen. So feel free to pull this down and check it yourself, or it may be a few days before I can vouch for the code. 

The `InitOptions` now has an `IsDebug` option that can be set. 
This overrides what the `SystemInfo` object attempts to determine (which currently does not work). 

Future work would be to replace `Assembly.GetEntryAssembly` (which returns null) with `Assembly.GetExecutingAssembly` (which will correctly return the assembly). That change is **not** in this PR.