### PR TITLE
Initial support for Aptabase.MAUI reliable delivery via persistent channel

### DIFF
--- a/src/Aptabase.Maui.csproj
+++ b/src/Aptabase.Maui.csproj
@@ -5,7 +5,7 @@
 		<Version>0.0.9</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<Description>Maui SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps</Description>
 		<Authors>Aptabase Team</Authors>
 		<Company>Aptabase</Company>
@@ -18,15 +18,15 @@
     	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<IncludeSymbols>true</IncludeSymbols>
     	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.22621.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
@@ -34,15 +34,20 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
 		<CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0-ios|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 		<None Include="..\etc\logo.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="DotNext.Threading" Version="5.9.0" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.70" />
+	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.70" />
 	</ItemGroup>
 </Project>

--- a/src/AptabaseClient.cs
+++ b/src/AptabaseClient.cs
@@ -3,6 +3,11 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Threading.Channels;
 
+// https://dotnet.github.io/dotNext/features/threading/channel.html
+using DotNext.Threading.Channels;
+using System.Text.Json;
+using System.Net;
+
 namespace Aptabase.Maui;
 
 /// <summary>
@@ -72,9 +77,23 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
 
         _http.DefaultRequestHeaders.Add("App-Key", appKey);
 
-        _channel = Channel.CreateUnbounded<EventData>();
+        if (options?.IsPersistent == true)
+        {
+            _pchannel = new PersistentEventDataChannel(new PersistentChannelOptions()
+            {
+                SingleReader = true,
+                ReliableEnumeration = true,
+                Location = Path.Combine(FileSystem.CacheDirectory, "EventData"),
+            });
 
-        _processingTask = Task.Run(ProcessEventsAsync);
+            _processingTask = Task.Run(ProcessPersistentEventsAsync);
+        }
+        else
+        {
+            _channel = Channel.CreateUnbounded<EventData>();
+
+            _processingTask = Task.Run(ProcessEventsAsync);
+        }
     }
 
     /// <summary>
@@ -84,6 +103,12 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
     /// <param name="props">A list of key/value pairs.</param>
     public void TrackEvent(string eventName, Dictionary<string, object>? props = null)
     {
+        if (_pchannel is not null)
+        {
+            TrackPersistentEvent(eventName, props);
+            return;
+        }
+
         if (_channel is null)
         {
             return;
@@ -108,6 +133,12 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
 
             while (_channel.Reader.TryRead(out EventData? eventData))
             {
+                if (eventData is not null)
+                {
+                    eventData.SessionId = _sessionId;
+                    eventData.SystemProps = _sysInfo;
+                }
+
                 await SendEventAsync(eventData);
             }
         }
@@ -127,15 +158,17 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
 
         try
         {
-            eventData.SessionId = _sessionId;
-            eventData.SystemProps = _sysInfo;
-
             var body = JsonContent.Create(eventData);
 
             var response = await _http.PostAsync("/api/v0/event", body);
 
             if (!response.IsSuccessStatusCode)
             {
+                if (response.StatusCode >= HttpStatusCode.InternalServerError || response.StatusCode == HttpStatusCode.RequestTimeout)
+                {
+                    throw new TaskCanceledException($"Server returned {response.StatusCode}");
+                }
+
                 var responseBody = await response.Content.ReadAsStringAsync();
 
                 _logger?.LogError("Failed to perform TrackEvent due to {StatusCode} and response body {Body}", response.StatusCode, responseBody);
@@ -143,6 +176,10 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
         }
         catch (Exception ex)
         {
+            if (_pchannel is not null) // retryable (later)
+            {
+                throw;
+            }
             _logger?.LogError(ex, "Failed to perform TrackEvent");
         }
     }
@@ -188,6 +225,7 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _channel?.Writer.Complete();
+        _pchannel?.Writer.Complete();
 
         if (_processingTask?.IsCompleted == false)
         {
@@ -197,5 +235,101 @@ public class AptabaseClient : IAptabaseClient, IAsyncDisposable
         _http?.Dispose();
 
         GC.SuppressFinalize(this);
+    }
+
+    // Persistent event channel support
+
+    private static int _maxPersistedEvents = 1000;
+    private const string _invalidPersistedEvent = "%%%DELETE%%%";
+    private readonly PersistentEventDataChannel? _pchannel;
+
+    private sealed class PersistentEventDataChannel : PersistentChannel<EventData, EventData>
+    {
+        internal PersistentEventDataChannel(PersistentChannelOptions options) : base(options)
+        {
+            if (options?.PartitionCapacity > 0)
+                _maxPersistedEvents = options.PartitionCapacity;
+        }
+
+        protected override async ValueTask<EventData> DeserializeAsync(Stream input, CancellationToken token)
+        {
+            try
+            {
+                // NOTE must catch any deserialization failure or ReliableReader.MoveNextAsync() will never consume the event!
+                return await JsonSerializer.DeserializeAsync<EventData?>(input, cancellationToken: token) ?? throw new Exception();
+            }
+            catch
+            {
+                return new EventData(_invalidPersistedEvent); // non-null, uniquely tagged event
+            }
+        }
+
+        protected override ValueTask SerializeAsync(EventData input, Stream output, CancellationToken token) =>
+            new (JsonSerializer.SerializeAsync(output, input, cancellationToken: token));
+    }
+
+    private async void TrackPersistentEvent(string eventName, Dictionary<string, object>? props = null)
+    {
+        if (_pchannel is null)
+        {
+            return;
+        }
+
+        RefreshSession();
+
+        var eventData = new EventData(eventName, props) { SessionId = _sessionId, SystemProps = _sysInfo };
+
+        try
+        {
+            await _pchannel.Writer.WriteAsync(eventData);    // NOTE TryWrite not supported on PersistentChannelWriter
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to perform TrackEvent");
+        }
+    }
+
+    private async ValueTask ProcessPersistentEventsAsync()
+    {
+        if (_pchannel is null)
+        {
+            return;
+        }
+
+        if (_http is null)
+        {
+            return;
+        }
+
+        while (true)
+        {
+            try
+            {
+                await foreach (EventData eventData in _pchannel.Reader.ReadAllAsync())
+                {
+                    if (_pchannel.RemainingCount > _maxPersistedEvents)
+                    {
+                        _logger?.LogError("ProcessEvents flushed {Name}@{Timestamp}", eventData.EventName, eventData.Timestamp);
+                        continue;
+                    }
+                    if (eventData.EventName == _invalidPersistedEvent)
+                    {
+                        _logger?.LogError("ProcessEvents undecodable event");
+                        continue;
+                    }
+                    await SendEventAsync(eventData);
+                }
+            }
+            catch (ChannelClosedException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Wait an extra HttpClient timeout, default 100s
+                _logger?.LogInformation(ex, "ProcessEvents retrying in {Seconds}s", _http.Timeout.TotalSeconds);
+                await Task.Delay((int)_http.Timeout.TotalMilliseconds);
+            }
+        }
     }
 }

--- a/src/AptabaseOptions.cs
+++ b/src/AptabaseOptions.cs
@@ -14,4 +14,9 @@ public class AptabaseOptions
     /// Indicates whether the client should operate in Debug mode. This setting is optional and helps in enabling debug-specific functionalities or logging.
     /// </summary>
     public bool? IsDebugMode { get; set; }
+
+    /// <summary>
+    /// Indicates whether the client should provide a reliable, persistent channel. This setting is optional and may be useful for crash reporting.
+    /// </summary>
+    public bool? IsPersistent { get; set; }
 }


### PR DESCRIPTION
Aptabase.MAUI.csproj:
- Add Dotnext.Threading for persistent channel
- Set iOS minimum platform to 11.0 to match MAUI
- .Net SDK to net8 (dotnext.threading requires it, also net7 no longer in support)

AptabaseOptions.cs:
- Add IsPersistent option to request new behavior

AptabaseClient.cs:
- Implementation