### PR TITLE
Implement simple crash reporting, log crashes and uncaught exceptions in a series of TrackEvents

### DIFF
--- a/src/AptabaseOptions.cs
+++ b/src/AptabaseOptions.cs
@@ -19,4 +19,10 @@ public class AptabaseOptions
     /// Indicates whether the client should provide a reliable, persistent channel. This setting is optional and may be useful for crash reporting.
     /// </summary>
     public bool? IsPersistent { get; set; }
+
+    /// <summary>
+    /// Indicates whether the client should provide simple crash reporting. This setting is optional and the use of a persistent channel is recommended.
+    /// When set, any uncaught exception is timestamped and logged with a TrackEvent. If stacktrace frames are provided by the exception, an additional TrackEvent is logged for each frame.
+    /// </summary>
+    public bool? IsSimpleCrashReporting { get; set; }
 }


### PR DESCRIPTION
[SimpleCrashReporting.md](https://github.com/user-attachments/files/16805587/SimpleCrashReporting.md)

# Simple crash reporting

Implement simple crash reporting for Aptabase.MAUI, to log crashes and uncaught exceptions (along with basic stacktraces), in a series of TrackEvent()s.

It's "simple" because it:
 - is very little code
 - uses existing Aptabase infrastructure
 - presents standard Exception.Stacktrace just like you'd see locally
 - provides reporting similar to AppCenter.Crashes

# More information

When used over an aptabase.maui persistent channel, it buffers any crash events and sends them as possible after the next app restart. If a persistent channel is **_not_** used, crashes may be incompletely reported, or not reported at all (if network
connectivity was unavailable at the time of the crash).

All uncaught exceptions are reported, therefore it functions as an "error" reporter as well. Events are reported as:

 "Crash" - fatal exception which terminates the app
 "Exception" - non-fatal uncaught exception thrown by something the app domain
 "TaskException" - uncaught exception in a background task, which are generally non-fatal

These events appear in the aptabase.com dashboard, and expanding them will reveal a chooser which offers entries grouped under a crash-specific high-precision UTC timestamp. Each entry then displays a set of events comprised of an index and a single line from the stacktrace. The first line ("00") contains the exception summary, and any following lines ("01".."NN") contain the stacktrace frame information.

When exported from the Aptabase UI, the aptabase sysinfo metadata is added and the rows can be sorted, filtered and analyzed easily. There are plenty of ways to isolate individual crashes, identify the app version and device type, etc to perform basic analysis of the software issue.

It's the author's belief that with IsPersistent and IsSimpleCrashReporter, Aptabase.MAUI can provide an alternative to AppCenter Crashes, in an even more privacy and open source centered way.

# Usage

Using the reporter requires only a single line of code. In your MauiApp Builder, simply add the following to your existing Aptabase initialization:

       .UseAptabase(<your app-key>,
    -->  new AptabaseOptions() { IsPersistent = true, IsSimpleCrashReporting = true }
       ).
       ...

Because it uses the existing Aptabase TrackEvent(), no protocol change is needed and the crashes are fully visible and exportable in the existing UI of any Aptabase server, including selfhosted.

# Sample log

Here's an excerpt from the exported log of a test app release build. Works the same on any MAUI platform (Android, iOS, Windows etc).
|event_name|string_props|os_name|os_version|
|--|--|--|--|
|Crash|{"2024-08-29T19:06:49.0673850Z":"12    at CrashTestDummy.Program.Main(String[] args)"}|iOS|16.7.10|
|Crash|{"2024-08-29T19:06:49.0673850Z":"11    at UIKit.UIApplication.Main(String[] , Type , Type )"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"10    at UIKit.UIApplication.UIApplicationMain(Int32 , String[] , IntPtr , IntPtr )"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"09    at UIKit.UIControlEventProxy.Activated()"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"08    at Microsoft.Maui.Handlers.ButtonHandler.ButtonEventProxy.OnButtonTouchUpInside(Object sender, EventArgs e)"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"07    at Microsoft.Maui.Controls.Button.Microsoft.Maui.IButton.Clicked()"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"06    at Microsoft.Maui.Controls.Button.SendClicked()"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"05    at Microsoft.Maui.Controls.ButtonElement.ElementClicked(VisualElement visualElement, IButtonElement ButtonElementManager)"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"04    at Microsoft.Maui.Controls.Button.Microsoft.Maui.Controls.Internals.IButtonElement.PropagateUpClicked()"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"03    at CrashTestDummy.MainPage.CrashBtn_Clicked(Object sender, EventArgs e)"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"02    at CrashTestDummy.MainPage.Stack3(Action a, Int32 i, Int32 j)"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"01    at CrashTestDummy.MainPage.\u003C\u003Ec.\u003CCrashBtn_Clicked\u003Eb__3_0()"}|iOS|16.7.10
|Crash|{"2024-08-29T19:06:49.0673850Z":"00 Fatal ApplicationException: Crash in UI thread"}|iOS|16.7.10
|||||
|TaskException|{"2024-08-29T19:18:51.1211410Z":"08    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task\u0026 , Thread )"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"07    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread , ExecutionContext , ContextCallback , Object )"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"06    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread , ExecutionContext , ContextCallback , Object )"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"05    at System.Threading.Tasks.Task.\u003C\u003Ec.\u003C.cctor\u003Eb__281_0(Object obj)"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"04    at System.Threading.Tasks.Task.InnerInvoke()"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"03    at CrashTestDummy.MainPage.\u003CTaskBtn_Clicked\u003Eb__4_0()"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"02    at CrashTestDummy.MainPage.Stack3(Action a, Int32 i, Int32 j)"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"01    at CrashTestDummy.MainPage.\u003C\u003Ec.\u003CTaskBtn_Clicked\u003Eb__4_1()"}|iOS|16.7.10
|TaskException|{"2024-08-29T19:18:51.1211410Z":"00 ApplicationException: Crash in background thread"}|iOS|16.7.10
