### PR TITLE
3 fixes for new crash reporter

### DIFF
--- a/src/AptabaseClient.cs
+++ b/src/AptabaseClient.cs
@@ -22,11 +22,6 @@ public class AptabaseClient : IAptabaseClient
 
     public Task TrackEvent(string eventName, Dictionary<string, object>? props = null)
     {
-        if (_channel is null)
-        {
-            return Task.CompletedTask;
-        }
-
         if (!_channel.Writer.TryWrite(new EventData(eventName, props)))
         {
             _logger?.LogError("Failed to perform TrackEvent");
@@ -37,11 +32,6 @@ public class AptabaseClient : IAptabaseClient
 
     private async Task ProcessEventsAsync()
     {
-        if (_channel is null)
-        {
-            return;
-        }
-
         try
         {
             while (await _channel.Reader.WaitToReadAsync())
@@ -84,14 +74,14 @@ public class AptabaseClient : IAptabaseClient
         }
         catch { }
 
-        _channel?.Writer.Complete();
+        _channel.Writer.Complete();
 
         if (_processingTask?.IsCompleted == false)
         {
             await _processingTask;
         }
 
-        _cts?.Dispose();
+        _cts.Dispose();
 
         await _client.DisposeAsync();
 

--- a/src/AptabaseClient.cs
+++ b/src/AptabaseClient.cs
@@ -78,7 +78,11 @@ public class AptabaseClient : IAptabaseClient
 
     public async ValueTask DisposeAsync()
     {
-        _cts?.Dispose();
+        try
+        {
+            _cts.Cancel();
+        }
+        catch { }
 
         _channel?.Writer.Complete();
 
@@ -86,6 +90,8 @@ public class AptabaseClient : IAptabaseClient
         {
             await _processingTask;
         }
+
+        _cts?.Dispose();
 
         await _client.DisposeAsync();
 

--- a/src/AptabaseExtensions.cs
+++ b/src/AptabaseExtensions.cs
@@ -19,20 +19,26 @@ public static class AptabaseExtensions
     {
         builder.Services.AddSingleton<IAptabaseClient>(serviceProvider =>
         {
+            IAptabaseClient client;
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-            if (options?.EnablePersistence == true)
+            if (options?.EnablePersistence != true)
             {
-                return new AptabasePersistentClient(appKey, options, loggerFactory.CreateLogger<AptabasePersistentClient>());
+                client = new AptabaseClient(appKey, options, loggerFactory.CreateLogger<AptabaseClient>());
+            }
+            else
+            {
+                client = new AptabasePersistentClient(appKey, options, loggerFactory.CreateLogger<AptabasePersistentClient>());
             }
 
-            return new AptabaseClient(appKey, options, loggerFactory.CreateLogger<AptabaseClient>());
-        });
+            if (options?.EnableCrashReporting == true)
 
-        if (options?.EnableCrashReporting == true)
-        {
-            builder.Services.AddSingleton<AptabaseCrashReporter>();
-        }
+            {
+                _ = new AptabaseCrashReporter(client, loggerFactory.CreateLogger<AptabaseCrashReporter>());
+            }
+
+            return client;
+        });
 
         return builder;
     }

--- a/src/AptabasePersistentClient.cs
+++ b/src/AptabasePersistentClient.cs
@@ -1,5 +1,6 @@
 ﻿using DotNext.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Platform;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
@@ -102,7 +103,11 @@ public class AptabasePersistentClient : IAptabaseClient
 
     public async ValueTask DisposeAsync()
     {
-        _cts?.Dispose();
+        try
+        {
+            _cts.Cancel();
+        }
+        catch { }
 
         _channel.Writer.Complete();
 
@@ -110,6 +115,8 @@ public class AptabasePersistentClient : IAptabaseClient
         {
             await _processingTask;
         }
+
+        _cts?.Dispose();
 
         await _client.DisposeAsync();
 

--- a/src/AptabasePersistentClient.cs
+++ b/src/AptabasePersistentClient.cs
@@ -50,11 +50,6 @@ public class AptabasePersistentClient : IAptabaseClient
 
     private async ValueTask ProcessEventsAsync()
     {
-        if (_channel is null)
-        {
-            return;
-        }
-
         while (true)
         {
             if (_cts.IsCancellationRequested)
@@ -116,7 +111,7 @@ public class AptabasePersistentClient : IAptabaseClient
             await _processingTask;
         }
 
-        _cts?.Dispose();
+        _cts.Dispose();
 
         await _client.DisposeAsync();
 


### PR DESCRIPTION
The new refactoring for the CrashReporter was not actually instantiating it. Fix that, and the cancellation for the event processors. Also clean up some unneeded null checks. Tested and working now.