### PR TITLE
2 improvements for new crash reporter

### DIFF
--- a/src/AptabaseCrashReporter.cs
+++ b/src/AptabaseCrashReporter.cs
@@ -61,6 +61,10 @@ public class AptabaseCrashReporter
         string stamp = $"{timeStamp:o}";
         int i = 0;
 
+        // include additional useful platform info
+        var di = DeviceInfo.Current;
+        thing += $" ({di.Platform}{di.VersionString}-{di.Manufacturer}-{di.Idiom}-{di.Model})";
+
         // event 00 is the exception summary
         _client.TrackEvent(error, new Dictionary<string, object> { { stamp, $"{i++:00} {thing}" } });
 

--- a/src/AptabaseCrashReporter.cs
+++ b/src/AptabaseCrashReporter.cs
@@ -65,6 +65,11 @@ public class AptabaseCrashReporter
         var di = DeviceInfo.Current;
         thing += $" ({di.Platform}{di.VersionString}-{di.Manufacturer}-{di.Idiom}-{di.Model})";
 
+        if (fatal && _client is AptabasePersistentClient apc)
+        {
+            apc.Paused = true;  // queue events but don't start sending, to avoid duplicates or errors
+        }
+
         // event 00 is the exception summary
         _client.TrackEvent(error, new Dictionary<string, object> { { stamp, $"{i++:00} {thing}" } });
 


### PR DESCRIPTION
A couple of improvements after further testing of the new merge...

It's important to pause sending persistent client events to the aptabase server when an app is crashing, otherwise duplicates appear in the logs. Often this is the first or second line of the stack trace, which becomes confusing. Restore the "pauseProcessing" behavior in the refactored AptabasePersistentClient.

Also, add some basic DeviceInfo platform information to the initial ("00") crash event, to make it more useful and meaningful in the aptabase UI without having to dig into a full "export".